### PR TITLE
Sintax Error on SP "DBAChecklist_JobStats"

### DIFF
--- a/DBAChecklistALL.sql
+++ b/DBAChecklistALL.sql
@@ -780,6 +780,7 @@ GO
 CREATE PROC [dbo].[DBAChecklist_JobStats]
 	@NumDays int,
 	@HTML nvarchar(max) out
+AS
 
 SET ANSI_WARNINGS OFF
 DECLARE @FromDate char(8)


### PR DESCRIPTION
On the [dbo].[DBAChecklist_JobStats] the syntax "AS" are requeried in
order to create this stored procedure